### PR TITLE
chore: included native build configuration files

### DIFF
--- a/.ci/macos-latest/resource-config.json
+++ b/.ci/macos-latest/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\Qcom/sun/jna/darwin-x86-64/libjnidispatch.jnilib\\E"
+  }]},
+  "bundles":[]
+}

--- a/.ci/ubuntu-latest/resource-config.json
+++ b/.ci/ubuntu-latest/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\Qcom/sun/jna/linux-x86-64/libjnidispatch.so\\E"
+  }]},
+  "bundles":[]
+}

--- a/.ci/windows-latest/resource-config.json
+++ b/.ci/windows-latest/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\Qcom/sun/jna/win32-x86-64/jnidispatch.dll\\E"
+  }]},
+  "bundles":[]
+}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -24,7 +24,9 @@ jobs:
         native-image-job-reports: 'true'
     - name: Build and test
       run: mvn package
-    - name: Test with trace agent
-      run: mvn -Ptrace test
+    - name: Prepare native test
+      run: |
+        mkdir -p src/test/resources/META-INF/native-image/
+        cp .ci/${{ matrix.os }}/resource-config.json src/test/resources/META-INF/native-image/
     - name: Native test
       run: mvn -Pnative test

--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,14 @@
 *.ear
 hs_err_pid*
 
-# Directories
-target/
-test-results-native/
-
 # OS generating files
 .DS_Store
 Thumbs.db
 
+# Directories and a file generated on build
+/target/
+/test-results-native/
+/src/test/resources/META-INF/native-image/resource-config.json
+
 # GraalVM native trace output directory
 /native-trace/
-/src/test/resources/META-INF/native-image/resource-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ test-results-native/
 .DS_Store
 Thumbs.db
 
-# GraalVM native build configuration files
-src/main/resources/META-INF/native-image
+# GraalVM native trace output directory
+/native-trace/
+/src/test/resources/META-INF/native-image/resource-config.json

--- a/README.md
+++ b/README.md
@@ -61,9 +61,22 @@ This library uses [ICU4J](https://icu.unicode.org/home) and [JNA](https://github
 Since the ICU4J's jar file includes data files, it is required to write those data files in `resource-config.json` which is one of native build configuration files.
 And since JNA uses JNI, reflection and so on, it is also required to write configurations into native build configuration files: `jni-config.json`, `proxy-config.json`, `reflect-config.json` and `resource-config.json`.
 
-These configuration files can be generated automatically with [Tracing Agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/).
-Therefore, the build tool `build.sh` in this library includes an option `trace-test` to run unit tests with the Trace Agent.
+These configuration files are included in the `src/main/resources/META-INF/native-image/com.github.sttk.linebreak/` directory.
+But only one configuration, JNA dynamic link library, is not included because it is platform-dependent.
+Please include the configuration of JNA dynamic link library for your platform into `reflect-config.json`.
+That configuration's format is as follows:
 
+```
+{
+  "resources":{
+  "includes":[ ... , {
+    "pattern":"\\Qcom/sun/jna/<osname>-<processor>/libjnidispatch.<extension>\\E"
+  }]},
+  "bundles":[ ... ]
+}
+```
+
+Here, the `<osname>`, `<processor>`, and `<extension>` can be obtained from the `attribute` element named `"Bundle-NativeCode"` in [JNA build file](https://github.com/java-native-access/jna/blob/master/build.xml). Or, download this project and run `./build.sh trace-test` to generate `reflect-config.json` and other configuration files.
 
 ## Supporting JDK versions
 

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,6 @@ if [[ "$#" == "0" ]]; then
   clean
   jar
   javadoc
-  trace_test
   native_test
 else
   for a in "$@"; do

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <profile>
       <id>trace</id>
       <properties>
-        <argLine>-agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image</argLine>
+        <argLine>-agentlib:native-image-agent=config-output-dir=native-trace</argLine>
       </properties>
     </profile>
     <profile>

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/jni-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/jni-config.json
@@ -1,0 +1,164 @@
+[
+{
+  "name":"com.sun.jna.Callback"
+},
+{
+  "name":"com.sun.jna.CallbackReference",
+  "methods":[{"name":"getCallback","parameterTypes":["java.lang.Class","com.sun.jna.Pointer","boolean"] }, {"name":"getFunctionPointer","parameterTypes":["com.sun.jna.Callback","boolean"] }, {"name":"getNativeString","parameterTypes":["java.lang.Object","boolean"] }, {"name":"initializeThread","parameterTypes":["com.sun.jna.Callback","com.sun.jna.CallbackReference$AttachOptions"] }]
+},
+{
+  "name":"com.sun.jna.CallbackReference$AttachOptions"
+},
+{
+  "name":"com.sun.jna.FromNativeConverter",
+  "methods":[{"name":"nativeType","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.jna.IntegerType",
+  "fields":[{"name":"value"}]
+},
+{
+  "name":"com.sun.jna.JNIEnv"
+},
+{
+  "name":"com.sun.jna.LastErrorException",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"com.sun.jna.Native",
+  "methods":[{"name":"dispose","parameterTypes":[] }, {"name":"fromNative","parameterTypes":["com.sun.jna.FromNativeConverter","java.lang.Object","java.lang.reflect.Method"] }, {"name":"fromNative","parameterTypes":["java.lang.Class","java.lang.Object"] }, {"name":"fromNative","parameterTypes":["java.lang.reflect.Method","java.lang.Object"] }, {"name":"nativeType","parameterTypes":["java.lang.Class"] }, {"name":"toNative","parameterTypes":["com.sun.jna.ToNativeConverter","java.lang.Object"] }]
+},
+{
+  "name":"com.sun.jna.Native$ffi_callback",
+  "methods":[{"name":"invoke","parameterTypes":["long","long","long"] }]
+},
+{
+  "name":"com.sun.jna.NativeMapped",
+  "methods":[{"name":"toNative","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.jna.Pointer",
+  "fields":[{"name":"peer"}],
+  "methods":[{"name":"<init>","parameterTypes":["long"] }]
+},
+{
+  "name":"com.sun.jna.PointerType",
+  "fields":[{"name":"pointer"}]
+},
+{
+  "name":"com.sun.jna.Structure",
+  "fields":[{"name":"memory"}, {"name":"typeInfo"}],
+  "methods":[{"name":"autoRead","parameterTypes":[] }, {"name":"autoWrite","parameterTypes":[] }, {"name":"getTypeInfo","parameterTypes":[] }, {"name":"newInstance","parameterTypes":["java.lang.Class","long"] }]
+},
+{
+  "name":"com.sun.jna.Structure$ByValue"
+},
+{
+  "name":"com.sun.jna.Structure$FFIType$FFITypes",
+  "fields":[{"name":"ffi_type_double"}, {"name":"ffi_type_float"}, {"name":"ffi_type_longdouble"}, {"name":"ffi_type_pointer"}, {"name":"ffi_type_sint16"}, {"name":"ffi_type_sint32"}, {"name":"ffi_type_sint64"}, {"name":"ffi_type_sint8"}, {"name":"ffi_type_uint16"}, {"name":"ffi_type_uint32"}, {"name":"ffi_type_uint64"}, {"name":"ffi_type_uint8"}, {"name":"ffi_type_void"}]
+},
+{
+  "name":"com.sun.jna.WString",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.lang.Boolean",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["boolean"] }]
+},
+{
+  "name":"java.lang.Byte",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["byte"] }]
+},
+{
+  "name":"java.lang.Character",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["char"] }]
+},
+{
+  "name":"java.lang.Class",
+  "methods":[{"name":"getComponentType","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.Double",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["double"] }]
+},
+{
+  "name":"java.lang.Float",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["float"] }]
+},
+{
+  "name":"java.lang.Integer",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["int"] }]
+},
+{
+  "name":"java.lang.Long",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["long"] }]
+},
+{
+  "name":"java.lang.Object",
+  "methods":[{"name":"toString","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.Short",
+  "fields":[{"name":"TYPE"}, {"name":"value"}],
+  "methods":[{"name":"<init>","parameterTypes":["short"] }]
+},
+{
+  "name":"java.lang.String",
+  "methods":[{"name":"<init>","parameterTypes":["byte[]"] }, {"name":"<init>","parameterTypes":["byte[]","java.lang.String"] }, {"name":"getBytes","parameterTypes":[] }, {"name":"getBytes","parameterTypes":["java.lang.String"] }, {"name":"lastIndexOf","parameterTypes":["int"] }, {"name":"substring","parameterTypes":["int"] }, {"name":"toCharArray","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.System",
+  "methods":[{"name":"getProperty","parameterTypes":["java.lang.String"] }, {"name":"setProperty","parameterTypes":["java.lang.String","java.lang.String"] }]
+},
+{
+  "name":"java.lang.Void",
+  "fields":[{"name":"TYPE"}]
+},
+{
+  "name":"java.lang.reflect.Method",
+  "methods":[{"name":"getParameterTypes","parameterTypes":[] }, {"name":"getReturnType","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.Buffer",
+  "methods":[{"name":"position","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.ByteBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.CharBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.DoubleBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.FloatBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.IntBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.LongBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.ShortBuffer",
+  "methods":[{"name":"array","parameterTypes":[] }, {"name":"arrayOffset","parameterTypes":[] }]
+},
+{
+  "name":"sun.management.VMManagementImpl",
+  "fields":[{"name":"compTimeMonitoringSupport"}, {"name":"currentThreadCpuTimeSupport"}, {"name":"objectMonitorUsageSupport"}, {"name":"otherThreadCpuTimeSupport"}, {"name":"remoteDiagnosticCommandsSupport"}, {"name":"synchronizerUsageSupport"}, {"name":"threadAllocatedMemorySupport"}, {"name":"threadContentionMonitoringSupport"}]
+}
+]

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/proxy-config.json
@@ -1,5 +1,8 @@
 [
   {
     "interfaces":["com.github.sttk.linebreak.terminal.UnixTerminal$C"]
+  },
+  {
+    "interfaces":["com.github.sttk.linebreak.terminal.WindowsTerminal$Kernel32"]
   }
 ]

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/proxy-config.json
@@ -1,0 +1,5 @@
+[
+  {
+    "interfaces":["com.github.sttk.linebreak.terminal.UnixTerminal$C"]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
@@ -1,0 +1,73 @@
+[
+{
+  "name":"com.github.sttk.linebreak.terminal.UnixTerminal$winsize",
+  "allDeclaredFields":true,
+  "fields":[{"name":"OPTIONS"}, {"name":"STRING_ENCODING"}, {"name":"STRUCTURE_ALIGNMENT"}, {"name":"TYPE_MAPPER"}]
+},
+{
+  "name":"com.sun.jna.CallbackProxy",
+  "methods":[{"name":"callback","parameterTypes":["java.lang.Object[]"] }]
+},
+{
+  "name":"com.sun.jna.NativeLong",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.Object",
+  "methods":[{"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"hashCode","parameterTypes":[] }, {"name":"toString","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.Throwable",
+  "methods":[{"name":"addSuppressed","parameterTypes":["java.lang.Throwable"] }]
+},
+{
+  "name":"java.lang.invoke.MethodHandle",
+  "methods":[{"name":"bindTo","parameterTypes":["java.lang.Object"] }, {"name":"invokeWithArguments","parameterTypes":["java.lang.Object[]"] }]
+},
+{
+  "name":"java.lang.invoke.MethodHandles",
+  "methods":[{"name":"lookup","parameterTypes":[] }, {"name":"privateLookupIn","parameterTypes":["java.lang.Class","java.lang.invoke.MethodHandles$Lookup"] }]
+},
+{
+  "name":"java.lang.invoke.MethodHandles$Lookup",
+  "methods":[{"name":"findSpecial","parameterTypes":["java.lang.Class","java.lang.String","java.lang.invoke.MethodType","java.lang.Class"] }, {"name":"in","parameterTypes":["java.lang.Class"] }, {"name":"unreflectSpecial","parameterTypes":["java.lang.reflect.Method","java.lang.Class"] }]
+},
+{
+  "name":"java.lang.invoke.MethodType",
+  "methods":[{"name":"methodType","parameterTypes":["java.lang.Class","java.lang.Class[]"] }]
+},
+{
+  "name":"java.lang.reflect.Method",
+  "methods":[{"name":"isDefault","parameterTypes":[] }, {"name":"isVarArgs","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.Buffer"
+},
+{
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "name":"java.util.concurrent.atomic.AtomicBoolean",
+  "fields":[{"name":"value"}]
+},
+{
+  "name":"java.util.concurrent.atomic.AtomicReference",
+  "fields":[{"name":"value"}]
+},
+{
+  "name":"org.apache.maven.surefire.junitplatform.JUnitPlatformProvider",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.maven.surefire.api.provider.ProviderParameters"] }]
+},
+{
+  "name":"org.apiguardian.api.API",
+  "queryAllPublicMethods":true
+},
+{
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]
+},
+{
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
@@ -69,5 +69,13 @@
 {
   "name":"sun.security.provider.SHA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.github.sttk.linebreak.terminal.WindowsTerminal$CONSOLE_SCREEN_BUFFER_INFO",
+  "allDeclaredFields":true,
+  "fields":[{"name":"OPTIONS"}, {"name":"STRING_ENCODING"}, {"name":"STRUCTURE_ALIGNMENT"}, {"name":"TYPE_MAPPER"}]
+},
+{
+  "name":"com.sun.jna.win32.DLLCallback"
 }
 ]

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/reflect-config.json
@@ -55,14 +55,6 @@
   "fields":[{"name":"value"}]
 },
 {
-  "name":"org.apache.maven.surefire.junitplatform.JUnitPlatformProvider",
-  "methods":[{"name":"<init>","parameterTypes":["org.apache.maven.surefire.api.provider.ProviderParameters"] }]
-},
-{
-  "name":"org.apiguardian.api.API",
-  "queryAllPublicMethods":true
-},
-{
   "name":"sun.security.provider.NativePRNG",
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]
 },

--- a/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.sttk.linebreak/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\Qcom/ibm/icu/ICUConfig.properties\\E"
+  }, {
+    "pattern":"\\Qcom/ibm/icu/impl/data/icudt74b/uprops.icu\\E"
+  }]},
+  "bundles":[]
+}


### PR DESCRIPTION
This PR adds some configuration files for native build.
By including these configuration files into a Jar file, there is no need to generate them later. But only one configuration for JNA dynamic link library cannot be included because it is platform-dependent. (The explanation about the JNA dynamic link library is added in `README.md`.)