### PR TITLE
fix: corrected bugs in lineBreakOpportunity

### DIFF
--- a/src/main/java/com/github/sttk/linebreak/LineIter.java
+++ b/src/main/java/com/github/sttk/linebreak/LineIter.java
@@ -114,7 +114,7 @@ public class LineIter {
 
     while (this.scanner.hasNext()) {
       int cp = this.scanner.next();
-      lineBreakOppotunity(cp, state);
+      lineBreakOpportunity(cp, state);
 
       if (state.lboType == LboType.Break) {
         line = trimRightAndToString(this.buffer);
@@ -246,7 +246,7 @@ public class LineIter {
     return line;
   }
 
-  void lineBreakOppotunity(int codepoint, LboState state) {
+  void lineBreakOpportunity(int codepoint, LboState state) {
     state.lboPrev = state.lboType;
 
     switch (codepoint) {
@@ -255,10 +255,10 @@ public class LineIter {
         state.openQuot = (byte)(state.openApos + 1);
         state.lboType = LboType.Before;
       } else { // close
-        state.openQuot = 0;
         if (state.openQuot < state.openApos) {
           state.openApos = 0;
         }
+        state.openQuot = 0;
         state.lboType = LboType.After;
       }
       return;
@@ -267,10 +267,10 @@ public class LineIter {
         state.openApos = (byte)(state.openQuot + 1);
         state.lboType = LboType.Before;
       } else { // close
-        state.openApos = 0;
         if (state.openApos < state.openQuot) {
           state.openQuot = 0;
         }
+        state.openApos = 0;
         state.lboType = LboType.After;
       }
       return;

--- a/src/test/java/com/github/sttk/linebreak/LineIterTest.java
+++ b/src/test/java/com/github/sttk/linebreak/LineIterTest.java
@@ -83,7 +83,7 @@ public class LineIterTest {
   }
 
   @Test
-  void testNext_breakAtLineBreakOppotunity() {
+  void testNext_breakAtLineBreakOpportunity() {
     var text = "1234567890 abcdefghij";
     var iter = new LineIter(text, 20);
 
@@ -140,7 +140,7 @@ public class LineIterTest {
   }
 
   @Test
-  void testNext_thereIsNoLineBreakOppotunity() {
+  void testNext_thereIsNoLineBreakOpportunity() {
     var text = "12345678901234567890abcdefghij";
     var iter = new LineIter(text, 20);
 


### PR DESCRIPTION
Closes #6 

This PR fixes bugs in `lineBreakOpportunity` function.
`openApos` or `openQuot` had been cleared before comparison between them.

And there were typo of `Opportunity` as `Oppotunity`.