### PR TITLE
cicd: changed macos architecture to aarch64 in CI

### DIFF
--- a/.ci/macos-latest/resource-config.json
+++ b/.ci/macos-latest/resource-config.json
@@ -1,7 +1,7 @@
 {
   "resources":{
   "includes":[{
-    "pattern":"\\Qcom/sun/jna/darwin-x86-64/libjnidispatch.jnilib\\E"
+    "pattern":"\\Qcom/sun/jna/darwin-aarch64/libjnidispatch.jnilib\\E"
   }]},
   "bundles":[]
 }


### PR DESCRIPTION
This PR changes the architecture of macos to `aarch64` because the CI error occured on macos when using `x86-64`.